### PR TITLE
Add Typographic utility class generator

### DIFF
--- a/lib/_utils-generator.scss
+++ b/lib/_utils-generator.scss
@@ -1,11 +1,20 @@
-$typograpy-set: (
+@import 'type-setting';
+
+$typography-set: (
   centi: (item: null)
 ) !default;
 
 @mixin get-type($type-map: $typography-set) {
   @each $selector, $props in $type-map {
+    $tracking: null !default;
+
+    @if map-has-key($props, tracking) {
+      $tracking: map-get($props, tracking);
+    }
+
     .t-#{$selector} {
-      stuff: blah;
+      @include type(map-get($props, font-size), map-get($props, leading),
+          map-get($props, weight), $tracking);
     }
   }
 }

--- a/lib/_utils-generator.scss
+++ b/lib/_utils-generator.scss
@@ -1,0 +1,11 @@
+$typograpy-set: (
+  centi: (item: null)
+) !default;
+
+@mixin get-type($type-map: $typography-set) {
+  @each $selector, $props in $type-map {
+    .t-#{$selector} {
+      stuff: blah;
+    }
+  }
+}

--- a/test/_utils-generator.scss
+++ b/test/_utils-generator.scss
@@ -1,4 +1,22 @@
 @import '../lib/utils-generator';
 
 @include test-module('Generate typography utility classes') {
+  @include test('Generate a list of selectors and their blocks [mixin]') {
+    @include assert('Given a map with selectors as keys and a map as the ' +
+        'value, return a list of selectors [mixin]') {
+      @include input {
+        $typograpy-style: (
+          centi: (item: null)
+        );
+
+        @include get-type($typograpy-style);
+      }
+
+      @include expect {
+        .t-centi {
+          stuff: blah;
+        }
+      }
+    }
+  }
 }

--- a/test/_utils-generator.scss
+++ b/test/_utils-generator.scss
@@ -1,0 +1,4 @@
+@import '../lib/utils-generator';
+
+@include test-module('Generate typography utility classes') {
+}

--- a/test/_utils-generator.scss
+++ b/test/_utils-generator.scss
@@ -1,25 +1,30 @@
 @import '../lib/utils-generator';
 
 @include test-module('Generate typography utility classes') {
-  @include test('Generate a list of selectors and their blocks [mixin]') {
-    @include assert('Given a map with selectors as keys and a map as the ' +
-        'value, return a list of selectors.') {
+  @include test('Generate typography utility classes [mixin]') {
+    @include assert('Given a map of identifires and properties, generate ' +
+        'a list of typography utility classes.') {
       @include input {
-        $typograpy-style: (
-          centi: (item: null),
-          milli: (item: null)
+        $typography-style: (
+          centi: (font-size: 14, leading: 18, weight: 400),
+          milli: (font-size: 12, leading: 18, weight: 700, tracking: -125)
         );
 
-        @include get-type($typograpy-style);
+        @include get-type($typography-style);
       }
 
       @include expect {
         .t-centi {
-          stuff: blah;
+          font-size: 0.875rem;
+          line-height: 1.28571;
+          font-weight: 700;
         }
 
         .t-milli {
-          stuff: blah;
+          font-size: 0.75rem;
+          line-height: 1.5;
+          font-weight: 700;
+          letter-spacing: -0.125em;
         }
       }
     }

--- a/test/_utils-generator.scss
+++ b/test/_utils-generator.scss
@@ -3,10 +3,11 @@
 @include test-module('Generate typography utility classes') {
   @include test('Generate a list of selectors and their blocks [mixin]') {
     @include assert('Given a map with selectors as keys and a map as the ' +
-        'value, return a list of selectors [mixin]') {
+        'value, return a list of selectors.') {
       @include input {
         $typograpy-style: (
-          centi: (item: null)
+          centi: (item: null),
+          milli: (item: null)
         );
 
         @include get-type($typograpy-style);
@@ -14,6 +15,10 @@
 
       @include expect {
         .t-centi {
+          stuff: blah;
+        }
+
+        .t-milli {
           stuff: blah;
         }
       }

--- a/test/index.scss
+++ b/test/index.scss
@@ -3,6 +3,7 @@
 @import '../typography';
 @import 'sizing/default';
 @import 'type-setting';
+@import 'utils-generator';
 
 // With config set
 // TODO: (@bitfyre) Find a better way to organize this.


### PR DESCRIPTION
Add mixin that takes a map with the simple metric system prefix as the selector for the key, and a map of typographic properties as the value. Iterate over the map setting the selector, and applying the css properties.
