### PR TITLE
Define `get-styles` mixin

### DIFF
--- a/lib/_utils-generator.scss
+++ b/lib/_utils-generator.scss
@@ -32,5 +32,7 @@ $typography-set: (
 
     @include type(map-get($styles, font-size), map-get($styles, leading),
         map-get($styles, weight), $tracking);
+  } @else {
+    @error "$key doesn't exist, was #{$key}";
   }
 }

--- a/lib/_utils-generator.scss
+++ b/lib/_utils-generator.scss
@@ -18,3 +18,6 @@ $typography-set: (
     }
   }
 }
+
+@mixin get-style($key, $type-map: $typography-set) {
+}

--- a/lib/_utils-generator.scss
+++ b/lib/_utils-generator.scss
@@ -20,4 +20,17 @@ $typography-set: (
 }
 
 @mixin get-style($key, $type-map: $typography-set) {
+  $styles: null !default;
+  $tracking: null !default;
+
+  @if map-has-key($type-map, $key) {
+    $styles: map-get($type-map, $key);
+
+    @if map-has-key($styles, tracking) {
+      $tracking: map-get($props, tracking);
+    }
+
+    @include type(map-get($styles, font-size), map-get($styles, leading),
+        map-get($styles, weight), $tracking);
+  }
 }

--- a/test/_utils-generator.scss
+++ b/test/_utils-generator.scss
@@ -30,3 +30,29 @@
     }
   }
 }
+
+@include test-module('Fetch Style from typograpy map') {
+  @include test('Fetch style from map based on key [mixin]') {
+    @include assert('Give a map and a key, return the styling the key') {
+      @include input {
+        $typography-style: (
+          peta: (font-size: 72, leading: 90, weight: 400),
+          centi: (font-size: 14, leading: 18, weight: 400),
+          milli: (font-size: 12, leading: 18, weight: 700, tracking: -125)
+        );
+
+        .header {
+          @include get-style(peta, $typography-style);
+        }
+      }
+
+      @include expect {
+        .header {
+          font-size: 4.5rem;
+          line-height: 1.25;
+          font-weight: 700;
+        }
+      }
+    }
+  }
+}

--- a/test/_utils-generator.scss
+++ b/test/_utils-generator.scss
@@ -36,7 +36,7 @@
     @include assert('Give a map and a key, return the styling the key') {
       @include input {
         $typography-style: (
-          peta: (font-size: 72, leading: 90, weight: 400),
+          peta: (font-size: 72, leading: 90, weight: 700),
           centi: (font-size: 14, leading: 18, weight: 400),
           milli: (font-size: 12, leading: 18, weight: 700, tracking: -125)
         );


### PR DESCRIPTION
The `get-styles` mixin should take a key from the typography-map and the typography-map itself. It should the return the style declarations based on the property values of that specific key.

Example:

``` scss
$typography-style: (
  peta: (font-size: 72, leading: 90, weight: 700),
  centi: (font-size: 14, leading: 18, weight: 400),
  milli: (font-size: 12, leading: 18, weight: 700, tracking: -125)
);

.Hero-title {
  @include get-style(peta, $typography-style);
}
```

Result:

``` css
.Hero-title  {
  font-size: 4.5rem;
  line-height: 1.25;
  font-weight: 700;
}
```
